### PR TITLE
do not start a session when nothing is written and no cookie sent

### DIFF
--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -40,7 +40,20 @@ class BasicTest extends TestCase
     }
 
     /** @test */
-    public function startsSessionOnFirstInteraction()
+    public function doesNotStartASessionWhenNoSessionIdGiven()
+    {
+        $session = new SessionInstance('session');
+        if (!empty(session_id())) {
+            $this->markTestSkipped('Session already started in previous tests');
+        }
+
+        $session->get('foo');
+
+        self::assertEmpty(session_id());
+    }
+
+    /** @test */
+    public function resetsSessionVariablesSetOutside()
     {
         $_SESSION['foo'] = 'bar';
         $session = new SessionInstance('session');
@@ -48,6 +61,20 @@ class BasicTest extends TestCase
         $session->get('foo');
 
         self::assertArrayNotHasKey('foo', $_SESSION);
+    }
+
+    /** @test */
+    public function startsSessionOnFirstInteraction()
+    {
+        $session = new SessionInstance('session');
+        if (!empty(session_id())) {
+            $this->markTestSkipped('Session already started in previous tests');
+        }
+
+        $session->set('foo', 'bar');
+
+        self::assertArrayHasKey('foo', $_SESSION);
+        self::assertNotEmpty(session_id());
     }
 
     /** @test */

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -64,16 +64,13 @@ class BasicTest extends TestCase
     }
 
     /** @test */
-    public function startsSessionOnFirstInteraction()
+    public function startsSessionWhenCookiePresent()
     {
+        $_COOKIE['session'] = 'abc123';
         $session = new SessionInstance('session');
-        if (!empty(session_id())) {
-            $this->markTestSkipped('Session already started in previous tests');
-        }
 
-        $session->set('foo', 'bar');
+        $session->get('foo');
 
-        self::assertArrayHasKey('foo', $_SESSION);
         self::assertNotEmpty(session_id());
     }
 

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -184,9 +184,17 @@ class CookieTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @test */
-    public function doesNotCookie()
+    public function doesNotSendCookie()
     {
         list($header) = self::requestWebserver('session.php?use_cookies=false');
+
+        self::assertNotCookieHeader($header, 'nbsession');
+    }
+
+    /** @test */
+    public function doesNotSendCookieWithoutWrite()
+    {
+        list($header) = self::requestWebserver('session.php?write=false');
 
         self::assertNotCookieHeader($header, 'nbsession');
     }

--- a/tests/public/session.php
+++ b/tests/public/session.php
@@ -19,7 +19,11 @@ foreach (['path', 'domain', 'lifetime', 'secure', 'httponly'] as $parameter) {
 
 $session = new \NbSessions\SessionInstance('nbsession');
 
-$session->get('foo');
+if (@$_GET['write'] !== 'false') {
+    $session->set('foo', 'bar');
+} else {
+    $session->get('foo');
+}
 
 if (@$_GET['destroy'] === 'true') {
     $session->destroy();


### PR DESCRIPTION
Also we had to fix that cookie got resend when set was called because
of the second start_session() after session_write_close().

This will solve #2 